### PR TITLE
Improve test coverage

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for MooseX-Exception-Base
 
+0.0.5   YYYY-MM-DD
+        Add additional tests (Adam Herzog)
+
 0.0.4   2015-01-24
         Updating for release of version 0.0.4
         Updated dependencies (Ivan Wills)

--- a/lib/MooseX/Exception/Base.pm
+++ b/lib/MooseX/Exception/Base.pm
@@ -72,7 +72,6 @@ sub verbose {
     for my $attribute (@attributes) {
         my $name = $attribute->name;
         next if !defined $self->$name;
-        next if !$attribute->does('MooseX::Exception::Stringify');
 
         local $_ = $self->$name;
         push @errors,
@@ -84,8 +83,7 @@ sub verbose {
 
     $verbose = defined $verbose ? $verbose : $self->_verbose;
     my $stack
-        = !defined $verbose ? $self->_stack
-        : $verbose == 0     ? ''
+        = $verbose == 0     ? ''
         : $verbose == 1     ? (split /\n/, $self->_stack)[0]
         :                     $self->_stack;
 

--- a/lib/MooseX/Exception/Base.pm
+++ b/lib/MooseX/Exception/Base.pm
@@ -196,6 +196,10 @@ L<Moose>, L<Exception::Class>
 
 Ivan Wills - (ivan.wills@gmail.com)
 
+=head1 CONTRIBUTORS
+
+Adam Herzog - adam@adamherzog.com
+
 =head1 LICENSE AND COPYRIGHT
 
 Copyright (c) 2012 Ivan Wills (14 Mullion Close Hornsby Heights NSW Australia 2077).

--- a/t/throw.t
+++ b/t/throw.t
@@ -15,6 +15,21 @@ has complex => (
     stringify      => sub {return $_},
 );
 
+package MyMultipleAttrs;
+use Moose; extends 'MooseX::Exception::Base';
+has first => (
+    is             => 'rw',
+    isa            => 'Str',
+    traits         => [qw{MooseX::Exception::Stringify}],
+    stringify      => sub {return $_},
+);
+has second => (
+    is             => 'rw',
+    isa            => 'Str',
+    traits         => [qw{MooseX::Exception::Stringify}],
+    stringify      => sub {return $_},
+);
+
 package main;
 
 use strict;
@@ -24,6 +39,9 @@ use Test::More;
 base();
 my_exception();
 complex();
+hashref_args();
+empty_attr();
+multiple_attrs();
 
 done_testing();
 
@@ -56,4 +74,33 @@ sub complex {
     is "$e", "test error\npre : The complex result : post", "Stringifys correctly";
 }
 
+sub hashref_args {
+    # Test calling throw with a hashref instead of a hash
+    eval { MooseX::Exception::Base->throw( { error => 'test error' } ) };
+    my $e = $@;
+    ok $e, 'Got an exception';
+    is "$e", "test error", "Stringifys correctly";
+}
+
+sub empty_attr {
+    # Test building an exception while omitting an attribute,
+    # in this case, omitting the 'complex' arg
+    eval { MyComplex->throw( error => 'test error' ) };
+    my $e = $@;
+    ok $e, 'Got an exception';
+    is "$e", "test error", "Stringifys correctly";
+}
+
+sub multiple_attrs {
+    eval {
+        MyMultipleAttrs->throw(
+            error  => 'test error',
+            first  => 'foo',
+            second => 'bar',
+        );
+    };
+    my $e = $@;
+    ok $e, 'Got an exception';
+    is "$e", "test error\nfoo\nbar", "Stringifys correctly";
+}
 


### PR DESCRIPTION
This brings overall test coverage to 100%.

Adds several tests:
- Test that throw() can be called with a hashref instead of a hash.
- Test that a stringfy attribute can be omitted correctly.
- Test that multiple stringify attributes are sorted correctly.

Also remove a couple lines of extraneous, unreachable code. Each line removed is a validation for data that will have already been appropriately filtered/defined by a private method or private attribute.
