### PR TITLE
Fix build instructions in README.

### DIFF
--- a/README
+++ b/README
@@ -7,10 +7,10 @@ INSTALLATION
 
 To install this module, run the following commands:
 
-    perl Build.PL
-    ./Build
-    ./Build test
-    ./Build install
+    perl Makefile.PL
+    make
+    make test
+    make install
 
 SUPPORT AND DOCUMENTATION
 
@@ -38,7 +38,7 @@ You can also look for information at:
 
 COPYRIGHT AND LICENCE
 
-Copyright (C) 2012 Ivan Wills
+Copyright (C) 2015 Ivan Wills
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of either: the GNU General Public License as published


### PR DESCRIPTION
Updating the README to include the correct build instructions, with the new dzil-based build.

(Also, updating the copyright year.)
